### PR TITLE
Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,13 @@ cloud provider or locally:
 Once you have a cluster, each experiment repo contains specific information on
 how to run it:
 
-- [MPI (LAMMPS and ParRes Kernels)](experiments/mpi/README.md)
-- [OpenMP (Covid)](experiments/covid/README.md)
+- [MPI (LAMMPS and ParRes Kernels)](https://github.com/faasm/experiment-mpi/blob/master/README.md)
+- [OpenMP (Covid)](https://github.com/faasm/experiment-covid)
 
 ## Setup
 
 ```bash
 git submodule update --init
-cd faasm
-git submodule update --init clients/cpp
-cd ..
 
 # Install the python dependencies
 source bin/workon.sh

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Once you have a cluster, each experiment repo contains specific information on
 how to run it:
 
 - [MPI (LAMMPS and ParRes Kernels)](https://github.com/faasm/experiment-mpi/blob/master/README.md)
-- [OpenMP (Covid)](https://github.com/faasm/experiment-covid)
+- [OpenMP (Covid)](https://github.com/faasm/experiment-covid/blob/master/README.md)
 
 ## Setup
 

--- a/bin/install_microk8s.sh
+++ b/bin/install_microk8s.sh
@@ -9,4 +9,6 @@ echo "Installing microk8s version ${K8S_MAJOR}"
 
 sudo snap install microk8s --classic --channel=${K8S_MAJOR}/stable
 
-sudo microk8s.enable istio
+# 31/08/21 - Disabling istio as otherwise the installation through Faasm's
+# "inv knative.install" fails
+# sudo microk8s.enable istio

--- a/docs/local.md
+++ b/docs/local.md
@@ -20,6 +20,20 @@ sudo microk8s status
 sudo microk8s start
 ```
 
+To run `kubectl` do:
+
+```bash
+rm -rf ~/.kube
+mkdir -p ~/.kube
+microk8s config > ~/.kube/config
+```
+
+Finally check with:
+
+```bash
+kubectl get nodes
+```
+
 From here you can follow the [Faasm k8s
 instructions](https://github.com/faasm/faasm/blob/master/docs/kubernetes.md) to
 set up Faasm in the cluster.

--- a/docs/local.md
+++ b/docs/local.md
@@ -20,18 +20,10 @@ sudo microk8s status
 sudo microk8s start
 ```
 
-To run `kubectl` do:
+Lastly, update the credentials for `kubectl` to point to the microk8s cluster:
 
 ```bash
-rm -rf ~/.kube
-mkdir -p ~/.kube
-microk8s config > ~/.kube/config
-```
-
-Finally check with:
-
-```bash
-kubectl get nodes
+inv uk8s.credentials
 ```
 
 From here you can follow the [Faasm k8s

--- a/docs/local.md
+++ b/docs/local.md
@@ -37,5 +37,5 @@ Be careful to also add any instructions in there that are specific to MicroK8s.
 The quickest way to completely reset the cluster is:
 
 ```bash
-sudo snap remove microk8s && ./bin/install_microk8s.sh
+inv uk8s.reset
 ```

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -4,10 +4,12 @@ from . import cluster
 from . import covid
 from . import lammps
 from . import storage
+from . import uk8s
 
 ns = Collection(
     cluster,
     covid,
     lammps,
     storage,
+    uk8s,
 )

--- a/tasks/cluster.py
+++ b/tasks/cluster.py
@@ -49,7 +49,7 @@ def list(ctx):
 @task
 def provision(ctx):
     """
-    Provision the cluster
+    Provision the AKS cluster
     """
     k8s_ver = get_k8s_version()
 
@@ -81,7 +81,7 @@ def details(ctx):
 @task
 def delete(ctx):
     """
-    Delete the cluster
+    Delete the AKS cluster
     """
     _run_aks_cmd(
         "delete",
@@ -95,7 +95,7 @@ def delete(ctx):
 @task
 def credentials(ctx):
     """
-    Get credentials for the cluster
+    Get credentials for the AKS cluster
     """
     # Set up the credentials
     _run_aks_cmd(

--- a/tasks/uk8s.py
+++ b/tasks/uk8s.py
@@ -1,0 +1,30 @@
+from invoke import task
+from subprocess import run
+
+from tasks.util.env import KUBECTL_BIN
+
+
+@task
+def credentials(ctx):
+    """
+    Set credentials for the uk8s cluster
+    """
+    # Delete existing .kube config directory
+    del_cmd = "sudo rm -rf ~/.kube"
+    print(del_cmd)
+    run(del_cmd, shell=True, check=True)
+
+    # Create new .kube config directory
+    mkdir_cmd = "mkdir -p ~/.kube"
+    print(mkdir_cmd)
+    run(mkdir_cmd, shell=True, check=True)
+
+    # Load the local config
+    config_cmd = "sudo microk8s config > ~/.kube/config"
+    print(config_cmd)
+    run(config_cmd, shell=True, check=True)
+
+    # Check we can access the cluster
+    cmd = "{} get nodes".format(KUBECTL_BIN)
+    print(cmd)
+    run(cmd, shell=True, check=True)

--- a/tasks/uk8s.py
+++ b/tasks/uk8s.py
@@ -1,7 +1,29 @@
 from invoke import task
 from subprocess import run
 
-from tasks.util.env import KUBECTL_BIN
+from tasks.util.env import (
+    KUBECTL_BIN,
+    PROJ_ROOT,
+)
+
+
+@task
+def reset(ctx):
+    """
+    Reset the uk8s cluster from scratch
+    """
+    # Delete existing .kube config directory
+    rm_cmd = "sudo snap remove microk8s"
+    print(rm_cmd)
+    run(rm_cmd, shell=True, check=True)
+
+    # Create new .kube config directory
+    install_cmd = "./bin/install_microk8s.sh"
+    print(install_cmd)
+    run(install_cmd, cwd=PROJ_ROOT, shell=True, check=True)
+
+    # Update credentials
+    credentials(ctx)
 
 
 @task


### PR DESCRIPTION
In this PR I correct a couple of nits in the docs and add two tasks to interact more easily with a `microk8s` cluster. 

Further, I comment out a line in which `Istio` was enabled through `microk8s`. In my setup, this was conflicting with the `knative.install` task in faasm. But we can discuss the `microk8s` setup offline.