### PR TITLE
Fixes for microk8s

### DIFF
--- a/bin/install_microk8s.sh
+++ b/bin/install_microk8s.sh
@@ -8,3 +8,8 @@ K8S_MAJOR=${K8S_VERSION:0:4}
 echo "Installing microk8s version ${K8S_MAJOR}"
 
 sudo snap install microk8s --classic --channel=${K8S_MAJOR}/stable
+
+# Enable add-ons required by faasm/ knative
+sudo microk8s enable dns
+sudo microk8s enable rbac
+sudo microk8s enable metallb:192.168.1.240/24

--- a/bin/install_microk8s.sh
+++ b/bin/install_microk8s.sh
@@ -8,7 +8,3 @@ K8S_MAJOR=${K8S_VERSION:0:4}
 echo "Installing microk8s version ${K8S_MAJOR}"
 
 sudo snap install microk8s --classic --channel=${K8S_MAJOR}/stable
-
-# 31/08/21 - Disabling istio as otherwise the installation through Faasm's
-# "inv knative.install" fails
-# sudo microk8s.enable istio

--- a/tasks/cluster.py
+++ b/tasks/cluster.py
@@ -5,7 +5,6 @@ from shutil import copy, rmtree
 from subprocess import run
 
 from tasks.util.env import (
-    PROJ_ROOT,
     BIN_DIR,
     GLOBAL_BIN_DIR,
     KUBECTL_BIN,
@@ -17,7 +16,7 @@ from tasks.util.env import (
 from tasks.util.version import get_k8s_version
 
 # Note - this must match the version used by Faasm
-KNATIVE_VERSION = "0.25.0"
+KNATIVE_VERSION = "0.24.0"
 K9S_VERSION = "0.24.15"
 
 

--- a/tasks/uk8s.py
+++ b/tasks/uk8s.py
@@ -8,16 +8,24 @@ from tasks.util.env import (
 
 
 @task
-def reset(ctx):
+def uninstall(ctx):
     """
-    Reset the uk8s cluster from scratch
+    Uninstall uk8s
     """
-    # Delete existing .kube config directory
     rm_cmd = "sudo snap remove microk8s"
     print(rm_cmd)
     run(rm_cmd, shell=True, check=True)
 
-    # Create new .kube config directory
+
+@task
+def reset(ctx):
+    """
+    Reset the uk8s cluster from scratch
+    """
+    # Uninstall the existing
+    uninstall(ctx)
+
+    # Install
     install_cmd = "./bin/install_microk8s.sh"
     print(install_cmd)
     run(install_cmd, cwd=PROJ_ROOT, shell=True, check=True)


### PR DESCRIPTION
- Fix add-on installs after removing Istio (previously installing istio would set up DNS and RBAC which we now have to do manually).
- Downgrade to more stable Knative version. [net-istio](https://github.com/knative-sandbox/net-istio/releases) 0.25.0 is still a pre-release.
- Add `metallb` add-on to allow our `LoadBalancer` services to get external IPs.