### PR TITLE
Add plot to compare resource usage between runs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 black==20.8b1
-hoststats==0.0.8
+hoststats==0.1.1
 invoke==1.5.0
 Jinja2==2.11.3
 matplotlib==3.3.4

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -3,6 +3,7 @@ from invoke import Collection
 from . import cluster
 from . import covid
 from . import lammps
+from . import monitor
 from . import storage
 from . import uk8s
 
@@ -10,6 +11,7 @@ ns = Collection(
     cluster,
     covid,
     lammps,
+    monitor,
     storage,
     uk8s,
 )

--- a/tasks/lammps.py
+++ b/tasks/lammps.py
@@ -19,7 +19,7 @@ PLOTS_DIR = join(PLOTS_ROOT, "lammps")
 BENCHMARKS = ["compute", "network"]
 PLOT_COORDS = [0, 1]
 
-# Each tuple in the list contains (1) the resource name in the hoststats result
+# Each tuple in the list contains the resource name in the hoststats result
 # object, the unit to display in the Y axis, and whether the measure is an
 # accumulated value or not.
 ALL_RESOURCES = [

--- a/tasks/monitor.py
+++ b/tasks/monitor.py
@@ -1,0 +1,32 @@
+from invoke import task
+from os.path import join
+from subprocess import run
+
+SHELL_IMG_NAME = "mcr.microsoft.com/aks/fundamental/base-ubuntu:v0.0.11"
+
+
+def _run_kubectl_cmd(args):
+    cmd = [
+        "kubectl",
+    ]
+    cmd.extend(args)
+
+    cmd = " ".join(cmd)
+    print(cmd)
+    run(cmd, shell=True, check=True)
+
+
+# 08/12/21 - To SSH into a node in an AKS pool, we follow Microsoft's tutorial:
+# https://docs.microsoft.com/en-us/azure/aks/ssh
+@task
+def ssh_node(ctx, node):
+    """
+    Get an SSH shell in a node in the pool
+    """
+    cmd = [
+        "debug",
+        "node/{}".format(node),
+        "-it --image={}".format(SHELL_IMG_NAME),
+    ]
+
+    _run_kubectl_cmd(cmd)

--- a/tasks/monitor.py
+++ b/tasks/monitor.py
@@ -21,7 +21,7 @@ def _run_kubectl_cmd(args):
 @task
 def ssh_node(ctx, node):
     """
-    Get an SSH shell in a node in the pool
+    Get an SSH shell in a node in the AKS cluster node pool
     """
     cmd = [
         "debug",


### PR DESCRIPTION
Changelog:
* Bump hoststats version to fix the bug patched in Shillaker/hoststats#21
* Add a task to SSH into a node in the AKS pool identified by node name (as explained [here](https://docs.microsoft.com/en-us/azure/aks/ssh)).
* Add a script to compare the resource usage between runs (more detail below).

In the resource usage comparison plot I also breakdown the usage by host. Further, I amend the current plots to plot measures that are an accumulated value appropriately.