### PR TITLE
Update Kernels Plot

### DIFF
--- a/tasks/kernels.py
+++ b/tasks/kernels.py
@@ -19,7 +19,7 @@ XLABELS = {
     "p2p": "p2p\nMPI_{Send,Recv}",
     "transpose": "transpose\nMPI_{Isend,Irecv}",
     "reduce": "reduce\nMPI_Reduce",
-    "sparse": "reduce\nMPI_Allgather",
+    "sparse": "sparse\nMPI_Allgather",
 }
 
 

--- a/tasks/kernels.py
+++ b/tasks/kernels.py
@@ -1,3 +1,4 @@
+from glob import glob
 from invoke import task
 from math import sqrt
 from os import makedirs
@@ -16,23 +17,22 @@ WASM_CSV = join(RESULTS_DIR, "kernels_wasm.csv")
 OUT_FILE = join(PLOTS_DIR, "slowdown.png")
 
 
-def _read_results(csv):
-    if not exists(csv):
-        raise RuntimeError("CSV not found: {}".format(csv))
-
-    results = pd.read_csv(csv)
-
-    # First filter only the timing stats, and then group by kernel
-    results = results.loc[results["StatName"] == "Avg time (s)"]
-    results = results.groupby("Kernel", as_index=False)
-
-    # Second, group by world size
+def _read_results(exp):
     result_dict = {}
-    for name, group in results:
-        result_dict[name] = [
-            group.groupby("WorldSize", as_index=False).mean(),
-            group.groupby("WorldSize", as_index=False).sem(),
-        ]
+
+    for csv in glob(join(RESULTS_DIR, "kernels_{}_*.csv".format(exp))):
+        results = pd.read_csv(csv)
+
+        # First filter only the timing stats, and then group by kernel
+        results = results.loc[results["StatName"] == "Avg time (s)"]
+        results = results.groupby("Kernel", as_index=False)
+
+        # Second, group by world size
+        for name, group in results:
+            result_dict[name] = [
+                group.groupby("WorldSize", as_index=False).mean(),
+                group.groupby("WorldSize", as_index=False).sem(),
+            ]
 
     return result_dict
 
@@ -84,11 +84,11 @@ def propagate_error(wasm_results, native_results, num_proc):
     ]
     native_times = [
         native_results[kern][0]["ActualTime"].tolist()[num_proc]
-        for kern in native_results.keys()
+        for kern in wasm_results.keys()
     ]
     native_errs = [
         native_results[kern][1]["ActualTime"].tolist()[num_proc]
-        for kern in native_results.keys()
+        for kern in wasm_results.keys()
     ]
 
     yerr = []
@@ -109,8 +109,8 @@ def plot(ctx):
     makedirs(PLOTS_DIR, exist_ok=True)
 
     # Load results and sanity check
-    native_results = _read_results(NATIVE_CSV)
-    wasm_results = _read_results(WASM_CSV)
+    native_results = _read_results("native")
+    wasm_results = _read_results("wasm")
     if not _check_results(native_results, wasm_results):
         return
 
@@ -143,7 +143,7 @@ def plot(ctx):
         ]
         native_times = [
             native_results[kern][0]["ActualTime"].tolist()[num_proc]
-            for kern in native_results.keys()
+            for kern in wasm_results.keys()
         ]
         # Each bar must be set at the midpoint of the right offset
         x = [x_b + num_proc * col_width + col_width / 2 for x_b in x_base]

--- a/tasks/kernels.py
+++ b/tasks/kernels.py
@@ -15,12 +15,22 @@ PLOTS_DIR = join(PLOTS_ROOT, "kernels")
 NATIVE_CSV = join(RESULTS_DIR, "kernels_native.csv")
 WASM_CSV = join(RESULTS_DIR, "kernels_wasm.csv")
 OUT_FILE = join(PLOTS_DIR, "slowdown.png")
+XLABELS = {
+    "p2p": "p2p\nMPI_{Send,Recv}",
+    "transpose": "transpose\nMPI_{Isend,Irecv}",
+    "reduce": "reduce\nMPI_Reduce",
+    "sparse": "reduce\nMPI_Allgather",
+}
 
 
 def _read_results(exp):
     result_dict = {}
 
     for csv in glob(join(RESULTS_DIR, "kernels_{}_*.csv".format(exp))):
+        # Blacklist two experiments we don't plot
+        if ("stencil" in csv) or ("nstream" in csv):
+            continue
+
         results = pd.read_csv(csv)
 
         # First filter only the timing stats, and then group by kernel
@@ -166,7 +176,7 @@ def plot(ctx):
     plt.xlim(xmin, xmax)
     plt.ylim(0, 3.5)
     ax.set_xticks(xs)
-    ax.set_xticklabels(wasm_results.keys())
+    ax.set_xticklabels([XLABELS[key] for key in wasm_results.keys()])
     ax.set_ylabel("Slowdown [faasm / native]")
     ax.set_title("Kernels time to completion slowdown Faasm vs Native")
     fig.tight_layout()


### PR DESCRIPTION
* Read data from a separate file per kernel, not a joint one. Helps with re-running just one kernel.
* Remove `stencil` and `nstream` plots
* Add most frequent MPI calls to the X axis labels.