### PR TITLE
Remove COVID experiment

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "experiments/covid"]
-	path = experiments/covid
-	url = https://github.com/faasm/experiment-covid
 [submodule "experiments/pywren"]
 	path = experiments/pywren
 	url = https://github.com/faasm/experiment-pywren


### PR DESCRIPTION
After the refactor there still was a dangling submodule to `experiment-covid`.