### PR TITLE
Fix VM delete-all task

### DIFF
--- a/tasks/vm.py
+++ b/tasks/vm.py
@@ -231,7 +231,7 @@ def delete_all(ctx):
     """
     res = _list_all_vms()
     for vm in res:
-        _vm_op("delete", vm["name"], ["--yes"])
+        delete(ctx, vm["name"])
 
 
 @task


### PR DESCRIPTION
Make `vm.delete-all` call `vm.delete` instead of the underlying operation.