### PR TITLE
Delete bulk-created VMs

### DIFF
--- a/docs/azure.md
+++ b/docs/azure.md
@@ -67,7 +67,7 @@ inv cluster.delete
 List any in existence:
 
 ```bash
-inv vm.list
+inv vm.list-all
 ```
 
 Create a new one:
@@ -79,13 +79,18 @@ inv vm.create
 Delete one:
 
 ```bash
+# Delete a specific VM and associated resources
 inv vm.delete <vm name>
 ```
 
 Delete all:
 
 ```bash
+# Delete all VMs and resources
 inv vm.delete-all
+
+# Delete all VMs and resources with given prefix
+inv vm.delete-all --prefix <some prefix>
 ```
 
 The size of VMs is determined in the script itself, so you can tweak it there if
@@ -104,7 +109,7 @@ inv vm.create -n 4
 List them to work out which ones you want to deploy on:
 
 ```bash
-inv vm.list
+inv vm.list-all
 ```
 
 If you just want to deploy on all the ones that are there, you can run the

--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -3,8 +3,13 @@
 All the commands in this file assume you've set up the Python virtual
 environment for this project as per the [README](README.md).
 
-These instructions are just about setting up k8s tooling, if you have a cluster
-set up with `kubectl` and `kn` working, you can follow the [Faasm k8s
+These instructions desribe:
+
+- Setting up k8s tooling like `kubectl` and `kn`
+- Setting up a k8s cluster on VMs
+
+If you already have a cluster set up with `kubectl` and `kn` working, you can
+just follow the [Faasm k8s
 docs](https://faasm.readthedocs.io/en/latest/source/kubernetes.html).
 
 ## Kubectl
@@ -109,5 +114,9 @@ kubectl get nodes
 ```
 
 and should see your VMs. If it doesn't work, make sure the right ports are open
-on your VMs (if running on Azure, you can see the [Azure docs](docs/azure.md) for how
-to do this).
+on your VMs (if running on Azure, you can see the [Azure docs](docs/azure.md)
+for how to do this).
+
+Once running, you can follow the [Faasm k8s
+docs](https://faasm.readthedocs.io/en/latest/source/kubernetes.html) to set up
+Faasm.

--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -108,4 +108,6 @@ To check you can run:
 kubectl get nodes
 ```
 
-and should see your VMs.
+and should see your VMs. If it doesn't work, make sure the right ports are open
+on your VMs (if running on Azure, you can see the [Azure docs](docs/azure.md) for how
+to do this).

--- a/tasks/vm.py
+++ b/tasks/vm.py
@@ -28,9 +28,10 @@ from tasks.util.env import (
 
 
 # Network components to be deleted, order matters
+NSG_COMPONENT_CMD = "nsg"
 VM_NET_COMPONENTS = [
     ("nic", "VMNic"),
-    ("nsg", "NSG"),
+    (NSG_COMPONENT_CMD, "NSG"),
     ("vnet", "VNET"),
     ("public-ip", "PublicIp"),
 ]
@@ -97,21 +98,44 @@ def _build_ssh_command(ip_addr):
     return "ssh -A -i {} {}@{}".format(AZURE_SSH_KEY, AZURE_VM_ADMIN, ip_addr)
 
 
-@task
-def create(ctx, region=AZURE_REGION, sgx=False, name=None, n=1):
+@task(
+    help={
+        "n": "Number of VM instances",
+        "name": "Name to be given to the VM(s)",
+        "region": "Azure region",
+        "sgx": "Enable SGX",
+        "vm": "Azure VM type",
+    }
+)
+def create(ctx, vm=None, region=AZURE_REGION, sgx=False, name=None, n=1):
     """
     Creates Azure VMs
     """
+
+    # WARNING: we rely on a name ending in an integer to detect whether it's
+    # been created by Azure in bulk. Therefore, don't have this base name end in
+    # an integer
     if not name:
         timestamp = datetime.now().strftime("%d%m%Y-%H%M%S")
-        name = "faasm-vm{}-{}".format("-sgx" if sgx else "", timestamp)
+        name = "faasm-{}-{}-vm".format("-sgx" if sgx else "", timestamp)
+
+    vm_image = AZURE_VM_IMAGE
+    vm_type = AZURE_STANDALONE_VM_SIZE
+
+    if vm:
+        vm_type = vm
+    elif sgx:
+        vm_image = AZURE_SGX_VM_IMAGE
+        vm_type = AZURE_SGX_VM_SIZE
 
     print(
-        "Creating VM {}, size {}, region {}".format(
-            name, AZURE_STANDALONE_VM_SIZE, region
+        "Creating {} VMs: name={} type={} region={} image={}".format(
+            n, name, vm_type, region, vm_image
         )
     )
 
+    # Note here how we specify that we want to delete the associted resources:
+    # https://docs.microsoft.com/en-us/azure/virtual-machines/delete?tabs=cli2
     cmd = [
         "az vm create",
         "--resource-group {}".format(AZURE_RESOURCE_GROUP),
@@ -119,22 +143,13 @@ def create(ctx, region=AZURE_REGION, sgx=False, name=None, n=1):
         "--admin-username {}".format(AZURE_VM_ADMIN),
         "--location {}".format(region),
         "--ssh-key-value {}".format(AZURE_PUB_SSH_KEY),
+        "--image {}".format(vm_image),
+        "--size {}".format(vm_type),
+        "--public-ip-sku Standard",
+        "--os-disk-delete-option delete",
+        "--data-disk-delete-option delete",
+        "--nic-delete-option delete",
     ]
-
-    if sgx:
-        cmd.extend(
-            [
-                "--image {}".format(AZURE_SGX_VM_IMAGE),
-                "--size {}".format(AZURE_SGX_VM_SIZE),
-            ]
-        )
-    else:
-        cmd.extend(
-            [
-                "--image {}".format(AZURE_VM_IMAGE),
-                "--size {}".format(AZURE_STANDALONE_VM_SIZE),
-            ]
-        )
 
     if n > 1:
         cmd.append("--count {}".format(n))
@@ -204,49 +219,90 @@ def delete(ctx, name):
     """
     Deletes the given Azure VM
     """
+
+    # If we've created VMs in bulk, they will have slightly different naming
+    # conventions to those created individually.
+    # If created in bulk, Azure will have added an extra integer to the end of
+    # the name, which we can look for
+
+    # The need for this function is suprirising, it would be nice if the az
+    # delete command could just delete everything for us. Discussion here:
+
+    last_char = name[-1]
+    is_bulk = last_char.isnumeric()
+
+    if is_bulk:
+        bulk_idx = last_char
+        bulk_base_name = name[:-1]
+
+        print(
+            "Assuming {} created in bulk (idx {}, base {})".format(
+                name, bulk_idx, bulk_base_name
+            )
+        )
+    else:
+        print("Assuming {} was not created in bulk".format(name))
+
+        bulk_idx = None
+        bulk_base_name = None
+
     # Get OS disk name
-    disk_out = _vm_op(
-        "show",
-        name,
-        [
-            "--query storageProfile.osDisk.managedDisk.id",
-        ],
-        capture=True,
-    )
-    os_disk = disk_out.split("/")[-1][:-2]
+    #    disk_out = _vm_op(
+    #        "show",
+    #        name,
+    #        [
+    #            "--query storageProfile.osDisk.managedDisk.id",
+    #        ],
+    #        capture=True,
+    #    )
+    #    os_disk = disk_out.split("/")[-1][:-2]
 
     # Delete the VM itself
     _vm_op("delete", name, ["--yes"])
 
     # Delete OS disk
-    delete_disk_cmd = [
-        "az disk delete",
-        "--resource-group {}".format(AZURE_RESOURCE_GROUP),
-        "--name {}".format(os_disk),
-        "--yes",
-    ]
 
-    delete_disk_cmd = " ".join(delete_disk_cmd)
-    print(delete_disk_cmd)
-    run(
-        delete_disk_cmd,
-        check=True,
-        shell=True,
-    )
 
-    # Delete all the network components
-    for component, suffix in VM_NET_COMPONENTS:
-        cmd = [
-            "az",
-            "network {}".format(component),
-            "delete",
-            "--resource-group {}".format(AZURE_RESOURCE_GROUP),
-            "--name {}{}".format(name, suffix),
-        ]
+#    delete_disk_cmd = [
+#        "az disk delete",
+#        "--resource-group {}".format(AZURE_RESOURCE_GROUP),
+#        "--name {}".format(os_disk),
+#        "--yes",
+#    ]
 
-        cmd = " ".join(cmd)
-        print(cmd)
-        run(cmd, shell=True, check=True)
+#    delete_disk_cmd = " ".join(delete_disk_cmd)
+#    print(delete_disk_cmd)
+#    run(
+#        delete_disk_cmd,
+#        check=True,
+#        shell=True,
+#    )
+
+# Delete all the network components
+#    for component, suffix in VM_NET_COMPONENTS:
+#        fail_on_error = True
+#
+#        if is_bulk and component == NSG_COMPONENT_CMD:
+#            # Azure create a single NSG for bulk-create VMs, so need to ignore
+#            # failures if it doesn't exist
+#            fail_on_error = False
+#            component_name = bulk_base_name + suffix
+#        elif is_bulk:
+#            component_name = bulk_base_name + suffix + bulk_idx
+#        else:
+#            component_name = name + suffix
+#
+#        cmd = [
+#            "az",
+#            "network {}".format(component),
+#            "delete",
+#            "--resource-group {}".format(AZURE_RESOURCE_GROUP),
+#            "--name {}".format(component_name),
+#        ]
+#
+#        cmd = " ".join(cmd)
+#        print(cmd)
+#        run(cmd, shell=True, check=fail_on_error)
 
 
 @task


### PR DESCRIPTION
We have two ways to create VMs, individually, or in bulk. When created in bulk, VMs have different naming, and extra resources shared resources are created. 

Our previous VM deletion didn't work for the bulk-created VMs, and if it failed once a VM had been deleted, there was no way to say "carry on and delete whatever's left"

Changes:

- Make deletion work for both single and bulk-created VMs
- Automatically delete OS disk, data disk and NIC via `vm create` delete options
- Add a catch-all deletion of all resources with the prefix of the VM name (can be used to clear up any stragglers)