### PR TITLE
Fixes to run sgx enclaves in aks

### DIFF
--- a/ansible/tasks/code.yml
+++ b/ansible/tasks/code.yml
@@ -26,4 +26,5 @@
   with_items:
     - "clients/cpp"
     - "clients/python"
+    - "faabric"
 

--- a/tasks/cluster.py
+++ b/tasks/cluster.py
@@ -68,7 +68,7 @@ def provision(
             "--kubernetes-version {}".format(k8s_ver),
             "--ssh-key-value {}".format(AZURE_PUB_SSH_KEY),
             "--location {}".format(location),
-            "{}".format("--enable-addons confcom" if sgx else ""),
+            "{}".format("--enable-addons confcom --enable-sgxquotehelper" if sgx else ""),
         ],
     )
 

--- a/tasks/cluster.py
+++ b/tasks/cluster.py
@@ -68,7 +68,11 @@ def provision(
             "--kubernetes-version {}".format(k8s_ver),
             "--ssh-key-value {}".format(AZURE_PUB_SSH_KEY),
             "--location {}".format(location),
-            "{}".format("--enable-addons confcom --enable-sgxquotehelper" if sgx else ""),
+            "{}".format(
+                "--enable-addons confcom --enable-sgxquotehelper"
+                if sgx
+                else ""
+            ),
         ],
     )
 

--- a/tasks/util/env.py
+++ b/tasks/util/env.py
@@ -70,7 +70,7 @@ AZURE_VM_IMAGE = "Canonical:0001-com-ubuntu-server-focal:20_04-lts:latest"
 AZURE_STANDALONE_VM_SIZE = "Standard_DS5_v2"
 
 AZURE_SGX_VM_IMAGE = "Canonical:UbuntuServer:18_04-lts-gen2:18.04.202109180"
-AZURE_SGX_VM_SIZE = "Standard_DC4s_v3"
+AZURE_SGX_VM_SIZE = "Standard_DC4ds_v3"
 
 # ----------------------------
 # Azure Kubernetes Service (AKS) Cluster

--- a/tasks/vm.py
+++ b/tasks/vm.py
@@ -183,9 +183,9 @@ def create(ctx, size=None, region=AZURE_REGION, sgx=False, name=None, n=1):
         "--image {}".format(vm_image),
         "--size {}".format(vm_size),
         "--public-ip-sku Standard",
-#         "--os-disk-delete-option delete",
-#         "--data-disk-delete-option delete",
-#         "--nic-delete-option delete",
+        "--os-disk-delete-option delete",
+        "--data-disk-delete-option delete",
+        "--nic-delete-option delete",
     ]
 
     if n > 1:

--- a/tasks/vm.py
+++ b/tasks/vm.py
@@ -183,9 +183,9 @@ def create(ctx, size=None, region=AZURE_REGION, sgx=False, name=None, n=1):
         "--image {}".format(vm_image),
         "--size {}".format(vm_size),
         "--public-ip-sku Standard",
-        "--os-disk-delete-option delete",
-        "--data-disk-delete-option delete",
-        "--nic-delete-option delete",
+#         "--os-disk-delete-option delete",
+#         "--data-disk-delete-option delete",
+#         "--nic-delete-option delete",
     ]
 
     if n > 1:


### PR DESCRIPTION
Fix to be able to attest pods running inside SGX enclaves. The bulk of the changes are in faasm/faasm#645.